### PR TITLE
pass correct, original, arguments to 'call'ed function of the value object

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -196,7 +196,12 @@ function Deferred(canceller){
     if (!dontThrow) {
       enqueue(function () {
         if (!handled) {
-          throw error;
+          if (typeof(error) === 'string') {
+            throw new Error(error);
+          }
+          else {
+            throw error;
+          }
         }
       });
     }


### PR DESCRIPTION
neat library Kris. this commit fixes a bug I encountered when using promise call. the args I expected to be applied were not. ie. call("someMethod", arg1, arg2) was invoking someMethod with no args.
