### PR TITLE
Allow external access to finished, isError

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -1,4 +1,3 @@
-
 // Kris Zyp
 // Updates/added features by ...Max... (Max Motovilov)
 
@@ -198,6 +197,12 @@ function Deferred(canceller){
       }
     }
   }
+  
+  // let user find out if promise is already resolved or rejected
+  this.isFinished = function() { return finished || isError; }
+  this.isResolved = function() { return finished; }
+  this.isRejected = function() { return isError; }
+  
   // calling resolve will resolve the promise
   this.resolve = this.callback = this.emitSuccess = function(value){
     notifyAll(value);


### PR DESCRIPTION
Finding out if a promise is already resolved or rejected does not seem to be possible right now, or at least in an unintuitive way. Therefore three methods where added to access the state of the promise:
isResolved, isRejeceted and isFinished (either rejected or resolved).
